### PR TITLE
Support koordinator gang scheduler plugin

### DIFF
--- a/pkg/controller.v1/common/pod.go
+++ b/pkg/controller.v1/common/pod.go
@@ -420,7 +420,8 @@ func (jc *JobController) createNewPod(job interface{}, rt string, index int, spe
 	core.SetRestartPolicy(podTemplate, spec)
 
 	// if gang-scheduling is enabled:
-	// if user has specified other scheduler, we report a warning without overriding any fields.
+	// 1. if user has specified other scheduler, we report a warning without overriding any fields.
+	// 2. if no SchedulerName is set for pods, then we set the SchedulerName to enabled scheduler name.
 	if jc.Config.EnableGangScheduling() {
 		if isCustomSchedulerSet(replicas, jc.PodGroupControl.GetSchedulerName()) {
 			errMsg := "Another scheduler is specified when gang-scheduling is enabled and it will not be overwritten"

--- a/pkg/controller.v1/control/podgroup_control.go
+++ b/pkg/controller.v1/control/podgroup_control.go
@@ -200,6 +200,9 @@ type KoordinatorControl struct {
 }
 
 func (s *KoordinatorControl) DecoratePodTemplateSpec(pts *corev1.PodTemplateSpec, job metav1.Object, _ string) {
+	if len(pts.Spec.SchedulerName) == 0 {
+		pts.Spec.SchedulerName = s.GetSchedulerName()
+	}
 	if pts.Labels == nil {
 		pts.Labels = make(map[string]string)
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**

Now support for volcano, scheduler-plugins has been added, and we can easily add koordinator gang-schedulers.

https://github.com/koordinator-sh/koordinator
